### PR TITLE
fix: /roomにて、キャラの移動に伴い画面も動いている内容の修正

### DIFF
--- a/src/routes/room/index.lazy.tsx
+++ b/src/routes/room/index.lazy.tsx
@@ -22,7 +22,7 @@ export const Room = () => {
 
   return (
     <div
-      className="min-h-screen bg-black text-white flex flex-col items-center"
+      className="min-h-[calc(100vh-64px-1px)] bg-black text-white flex flex-col items-center" // header(16*4=64px), shared hr(1px)
       style={{
         WebkitUserSelect: 'none' /* Safari */,
         userSelect: 'none',


### PR DESCRIPTION
## 概要

大変勉強になるプロジェクトをありがとうございます。
Webサイトにて冒険を遊ばせていただいた際、使い勝手の面で少しだけ改善できそうな点があったため、PRとして提案させていただきました。

プロジェクトの方針と合わない場合は、遠慮なくクローズしていただいて問題ありません。

## 気づいた点

hrが1px縦幅を持っている
<img width="600" height="360" alt="スクリーンショット 2025-12-29 180819" src="https://github.com/user-attachments/assets/13a7d783-f530-49d7-a9f1-9ea6bdfa6c75" />

headerの場所を確保するためのpt-16が64px
mainの表示部分が100vh
<img width="600" height="384" alt="スクリーンショット 2025-12-29 180943" src="https://github.com/user-attachments/assets/76800c7b-f87a-4ba3-9351-8f926e1a5d79" />

上記を足すと100vh+64px+1px = 100vh+65pxとなり、65px分画面の立幅を超過している

## 変更詳細
mainの立幅をはみ出ている分（header+共通hr）を、100vhから差し引くことで画面の縦幅いっぱいに収めるよう変更

縦幅要素100vh(main)+header(64px)+共通hr(1px)=100vh+65px 
→(100vh-64px-1px) + 64px +1px = 100vh

　
## この変更で改善される内容
【修正前】
・スクロールバーが表示されている
・キャラの縦方向移動時に、スクロールバーが反応し画面も同時に動いている
<img width="405" height="492" alt="スクリーンショット 2025-12-29 181534" src="https://github.com/user-attachments/assets/47ed4ce6-fe56-4c7a-8ab8-423b6d123546" />
・下までスクロールした際に、ヘッダー部分に映像が少し重なっている
<img width="404" height="497" alt="スクリーンショット 2025-12-29 181522" src="https://github.com/user-attachments/assets/4f2a1da8-06df-4543-a6f6-51c057288aaf" />
【修正後】
・スクロールバーがなくなる
・キャラの縦方向移動時に、画面が動かなくなる
<img width="394" height="493" alt="スクリーンショット 2025-12-29 182716" src="https://github.com/user-attachments/assets/78af1ecb-bcd9-426d-8826-8e87d8141cd7" />
<img width="394" height="494" alt="スクリーンショット 2025-12-29 182628" src="https://github.com/user-attachments/assets/9aefb696-556b-473e-bd8a-515627141af3" />
